### PR TITLE
first-install bootstrapping (route unix to nix)

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+dotfiles.ranolp.dev

--- a/setup
+++ b/setup
@@ -1,0 +1,9 @@
+echo @'
+:' > /dev/null
+:; curl -L dotfiles.ranolp.dev/xpkg/setup-scripts/sh.sh | sh; exit
+@curl -L dotfiles.ranolp.dev/xpkg/setup-scripts/batch.bat > %Temp%\dotfiles-setup.bat
+@%Temp%\dotfiles-setup.bat
+@del %Temp%\dotfiles-setup.bat
+@exit
+'@ | Out-Null
+Invoke-WebRequest dotfiles.ranolp.dev/xpkg/setup-scripts/powershell.ps1 | Invoke-Expression

--- a/xpkg/setup-scripts/batch.bat
+++ b/xpkg/setup-scripts/batch.bat
@@ -1,0 +1,27 @@
+@echo off
+cls
+echo You are now installing RanolP's dotfiles...
+echo Environment : Windows + Batch
+
+echo Installing essential packages...
+echo You may interfered with several popups.
+:: Git for Windows
+echo $ winget install --exact --id Git.Git
+echo y | winget install --exact --id Git.Git
+:: nushell
+echo $ winget install --exact --id Nushell.Nushell
+echo y | winget install --exact --id Nushell.Nushell
+:: uutils coreutils
+echo $ winget install --exact --id uutils.coreutils
+echo y | winget install --exact --id uutils.coreutils
+:: gsudo
+echo $ winget install --exact --id gerardog.gsudo
+echo y | winget install --exact --id gerardog.gsudo
+
+:: refresh "Path" env var
+echo Refreshing paths for getting "git" and "nu" executable...
+curl -L dotfiles.ranolp.dev/utils/@windows/refresh-path.bat > %Temp%\refresh-path.bat
+call %Temp%\refresh-path.bat
+
+:: run common windows setup script
+nu -c "nu -c (http get https://dotfiles.ranolp.dev/xpkg/setup-scripts/nu.nu)"

--- a/xpkg/setup-scripts/nu.nu
+++ b/xpkg/setup-scripts/nu.nu
@@ -1,0 +1,5 @@
+#!/usr/bin/env nu
+echo 'Cloning git repository...'
+cd ~
+rm -rf .dotfiles
+git clone https://github.com/RanolP/.dotfiles.git

--- a/xpkg/setup-scripts/powershell.ps1
+++ b/xpkg/setup-scripts/powershell.ps1
@@ -1,0 +1,8 @@
+if ([System.Environment]::OSVersion.Platform -ne 'Win32NT') {
+    Write-Output "It does not supports powershell with non-Windows environment. try bash or similar alternatives."
+    exit 1
+}
+
+Clear-Host
+Write-Output "You are now installing RanolP's dotfiles..."
+Write-Output "Environment : Windows + PowerShell"

--- a/xpkg/setup-scripts/sh.sh
+++ b/xpkg/setup-scripts/sh.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+clear
+echo "RanolP's dotfiles use nix on macOS/Linux."
+echo "xpkg (the Windows installer) does not apply here."
+echo
+echo "Set this machine up with nix:"
+echo "  1. Install nix:"
+echo "     sh <(curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install)"
+echo "  2. Clone the dotfiles:"
+echo "     git clone https://github.com/RanolP/.dotfiles.git ~/.dotfiles"
+echo "  3. Apply the flake:"
+echo "     # macOS: sudo nix run nix-darwin -- switch --flake ~/.dotfiles/nix#ranolp-work-MBP-26"
+echo "     # Linux: nix run home-manager -- switch --flake ~/.dotfiles/nix#ranolp-archwsl -b before-hm"
+echo
+echo "See https://dotfiles.ranolp.dev for the full guide."


### PR DESCRIPTION
## What this does

**first-install bootstrapping.** The root `setup` entry point bootstraps a fresh machine. nix now owns macOS/Linux, so the unix path hands off to nix instead of xpkg.

## Changes
- `xpkg/setup-scripts/sh.sh` → redirect: install nix, clone the repo, apply the flake (darwin for macOS, home-manager for Linux)
- remove `xpkg/setup-scripts/linux/arch.sh` (nix owns the Linux bootstrap)

Windows bootstrapping (`batch.bat` / `powershell.ps1` / `nu.nu`) is unchanged.

## Note
Stacked on #11 (`claude/xpkg-windows-setup`) — merge #11 first, or retarget to `main` after it lands. Replaces the mis-named, auto-closed #12 (`claude/xpkg-windows-only`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
